### PR TITLE
quote objects to preserve (lower) case in hsqldb

### DIFF
--- a/src/main/migrations/changelog.xml
+++ b/src/main/migrations/changelog.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd"
+    objectQuotingStrategy="QUOTE_ALL_OBJECTS" >
 
     <changeSet id="schema_datamanagement" author="kshakir">
 


### PR DESCRIPTION
Add objectQuotingStrategy="QUOTE_ALL_OBJECTS" to liquibase so we can properly preserve case in hsqldb (and postgres). Required upgrading the liquibase schema/xsd version.
