### PR TITLE
use pre-defined swagger base url instead of trying to calculate paths

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/DataManagementServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/DataManagementServiceActor.scala
@@ -66,10 +66,9 @@ class DataManagementServiceActor extends HttpServiceActor with ActorLogging {
       pathPrefix("swagger") {
         // if the user just hits "swagger", redirect to the index page with our api docs specified on the url
         pathEndOrSingleSlash { p =>
-          // dynamically calculate the context path, which may be different in various environments
-          val path = p.request.uri.path.toString
-          val dynamicContext = path.substring(0, path.indexOf("swagger"))
-          p.redirect("/swagger/index.html?url=" + dynamicContext + "api-docs", TemporaryRedirect)
+          // the base context path may be different in various environments
+          val dynamicContext = DataManagementConfig.SwaggerConfig.baseUrl
+          p.redirect(dynamicContext + "swagger/index.html?url=" + dynamicContext + "api-docs", TemporaryRedirect)
         } ~
           pathPrefix("swagger/index.html") {
             getFromResource("META-INF/resources/webjars/swagger-ui/2.1.8-M1/index.html")


### PR DESCRIPTION
I've tested this locally by setting up a local nginx proxy, so I have confidence, but I really want to get this into CI before being certain. If this works well in CI, I'll update vault-api with the same code.
