### PR TITLE
add an ExceptionHandler to the test that generates a large stack trace

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/AnalysisServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/AnalysisServiceSpec.scala
@@ -61,14 +61,15 @@ class AnalysisServiceSpec extends DataManagementDatabaseFreeSpec with AnalysisSe
       "POST with a bad input id should return a bad request error" in {
         val badInput = input.map(_ :+ "intentionallyBadForeignKey")
         // this test is expected to generate an integrity constraint exception
-        implicit def myExceptionHandler =
+        implicit def myExceptionHandler: ExceptionHandler =
           ExceptionHandler {
-            case e:java.sql.SQLIntegrityConstraintViolationException =>
+            case e: java.sql.SQLIntegrityConstraintViolationException =>
               complete(InternalServerError, "intentionally handled error")
           }
 
         Post(pathBase, Analysis(badInput, metadata, files)) ~> OpenAMSession ~> sealRoute(ingestRoute) ~> check {
           status should be(InternalServerError)
+          responseAs[String] should be("intentionally handled error")
         }
       }
 

--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/AnalysisServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/AnalysisServiceSpec.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.vault.datamanagement.model.{Analysis, UnmappedBAM
 import org.broadinstitute.dsde.vault.datamanagement.services.JsonImplicits._
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
+import spray.routing.ExceptionHandler
 
 class AnalysisServiceSpec extends DataManagementDatabaseFreeSpec with AnalysisService {
 
@@ -59,6 +60,13 @@ class AnalysisServiceSpec extends DataManagementDatabaseFreeSpec with AnalysisSe
 
       "POST with a bad input id should return a bad request error" in {
         val badInput = input.map(_ :+ "intentionallyBadForeignKey")
+        // this test is expected to generate an integrity constraint exception
+        implicit def myExceptionHandler =
+          ExceptionHandler {
+            case e:java.sql.SQLIntegrityConstraintViolationException =>
+              complete(InternalServerError, "intentionally handled error")
+          }
+
         Post(pathBase, Analysis(badInput, metadata, files)) ~> OpenAMSession ~> sealRoute(ingestRoute) ~> check {
           status should be(InternalServerError)
         }


### PR DESCRIPTION
the test I changed below intentionally passes bad data to the create-analysis API. This results in an integrity constraint exception thrown all the way up from the database. Previously, we wrote this entire stack to console and tested that the API returned a 500.

Now, we handle that exception and don't write it out, making the test output much cleaner.

The drawback to this approach is that we can no longer test that the original API returns a 500. However, we didn't have any custom logic around that - we simply relied on the default spray logic that returns a 500 when an exception is thrown. I couldn't find a way around this restriction, but it feels okay. I'm open to suggestions, though.
