### PR TITLE
Added 'properties' field to UBAM and Analysis objects

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/Analysis.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/Analysis.scala
@@ -15,6 +15,9 @@ case class Analysis
 
   @(ApiModelProperty@field)(value = "The output files associated with this Analysis, each with a unique user-supplied string key.", required = false)
   files: Option[Map[String, String]] = None,
+  
+  @(ApiModelProperty@field)(value = "The properties of this Analysis", required = false)
+  properties: Option[Map[String, String]] = None,
 
   @(ApiModelProperty@field)(value = "The Vault ID of this Analysis", required = false)
   id: Option[String] = None

--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/Properties.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/Properties.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.vault.datamanagement.model
+
+object Properties {
+  val CreatedBy = "createdBy"
+  val CreatedDate = "createdDate"
+  val ModifiedBy = "modifiedBy"
+  val ModifiedDate = "modifiedDate"
+}

--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/UnmappedBAM.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/UnmappedBAM.scala
@@ -13,6 +13,9 @@ case class UnmappedBAM
   @(ApiModelProperty@field)(value = "The metadata key-value pairs associated with this unmapped BAM.", required = true)
   metadata: Map[String, String],
 
+  @(ApiModelProperty@field)(value = "The properties of this unmapped BAM", required = false)
+  properties: Option[Map[String, String]] = None,
+  
   @(ApiModelProperty@field)(value = "The Vault ID of this unmapped BAM", required = false)
   id: Option[String] = None
   )

--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/AnalysisService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/AnalysisService.scala
@@ -19,7 +19,7 @@ trait AnalysisService extends HttpService {
   private implicit val ec = actorRefFactory.dispatcher
 
   private final val ApiPrefix = "analyses"
-  private final val ApiVersions = "v1"
+  private final val ApiVersions = "v1,v2"
 
   val routes = describeRoute ~ ingestRoute ~ completeRoute
 
@@ -45,10 +45,7 @@ trait AnalysisService extends HttpService {
         rejectEmptyResponse {
           respondWithMediaType(`application/json`) {
             complete {
-              version match {
-                case _ =>
-                  DataManagementController.getAnalysis(id).map(_.toJson.prettyPrint)
-              }
+              DataManagementController.getAnalysis(id, version).map(_.toJson.prettyPrint)
             }
           }
         }
@@ -75,10 +72,7 @@ trait AnalysisService extends HttpService {
           entity(as[Analysis]) { analysis =>
             respondWithMediaType(`application/json`) {
               complete {
-                version match {
-                  case _ =>
-                    DataManagementController.createAnalysis(analysis, commonName).toJson.prettyPrint
-                }
+                DataManagementController.createAnalysis(analysis, commonName, version).toJson.prettyPrint
               }
             }
           }
@@ -107,10 +101,7 @@ trait AnalysisService extends HttpService {
           entity(as[Analysis]) { analysis =>
             respondWithMediaType(`application/json`) {
               complete {
-                version match {
-                  case _ =>
-                    DataManagementController.completeAnalysis(id, analysis.files.get, commonName).toJson.prettyPrint
-                }
+                DataManagementController.completeAnalysis(id, analysis.files.get, commonName, version).toJson.prettyPrint
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/JsonImplicits.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/JsonImplicits.scala
@@ -5,7 +5,7 @@ import spray.json.DefaultJsonProtocol
 
 object JsonImplicits extends DefaultJsonProtocol {
   // via https://github.com/jacobus/s4/blob/8dc0fbb04c788c892cb93975cf12f277006b0095/src/main/scala/s4/rest/S4Service.scala
-  implicit val impUnmappedBAM = jsonFormat3(UnmappedBAM)
-  implicit val impAnalysis = jsonFormat4(Analysis)
+  implicit val impUnmappedBAM = jsonFormat4(UnmappedBAM)
+  implicit val impAnalysis = jsonFormat5(Analysis)
   implicit val impEntitySearchResult = jsonFormat2(EntitySearchResult)
 }

--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/UnmappedBAMService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/UnmappedBAMService.scala
@@ -17,7 +17,7 @@ trait UnmappedBAMService extends HttpService {
   private implicit val ec = actorRefFactory.dispatcher
 
   private final val ApiPrefix = "ubams"
-  private final val ApiVersions = "v1"
+  private final val ApiVersions = "v1,v2"
 
   val routes = describeRoute ~ ingestRoute
 
@@ -43,10 +43,7 @@ trait UnmappedBAMService extends HttpService {
         rejectEmptyResponse {
           respondWithMediaType(`application/json`) {
             complete {
-              version match {
-                case _ =>
-                  DataManagementController.getUnmappedBAM(id).map(_.toJson.prettyPrint)
-              }
+              DataManagementController.getUnmappedBAM(id, version).map(_.toJson.prettyPrint)
             }
           }
         }
@@ -72,10 +69,7 @@ trait UnmappedBAMService extends HttpService {
           entity(as[UnmappedBAM]) { unmappedBAM =>
             respondWithMediaType(`application/json`) {
               complete {
-                version match {
-                  case _ =>
-                    DataManagementController.createUnmappedBAM(unmappedBAM, commonName).toJson.prettyPrint
-                }
+                DataManagementController.createUnmappedBAM(unmappedBAM, commonName, version).toJson.prettyPrint
               }
             }
           }

--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/LookupServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/LookupServiceSpec.scala
@@ -15,7 +15,8 @@ class LookupServiceSpec extends DataManagementDatabaseFreeSpec with LookupServic
     val versions = Table(
       "version",
       None,
-      Some(1)
+      Option(1),
+      Option(2)
     )
 
     forAll(versions) { (version: Option[Int]) =>
@@ -24,7 +25,7 @@ class LookupServiceSpec extends DataManagementDatabaseFreeSpec with LookupServic
       s"when accessing the $pathBase/{entityType}/{attributeName}/{attributeValue} path" - {
         val testValue = UUID.randomUUID().toString
         val metadata = Map("sameKey" -> "sameValue", "uniqueTest" -> testValue)
-        val entityGUID = DataManagementController.createUnmappedBAM(UnmappedBAM(Map.empty, metadata), "LookupServiceSpec").id.get
+        val entityGUID = DataManagementController.createUnmappedBAM(UnmappedBAM(Map.empty, metadata), "LookupServiceSpec", Option(1)).id.get
 
         "Lookup should return previously stored unmapped BAM" in {
           Get(s"$pathBase/ubam/uniqueTest/$testValue") ~> lookupEntityByTypeAttributeNameValueRoute ~> check {


### PR DESCRIPTION
Currently this map only contains the created_by, created_date, modified_by, and modified_date (when present), but adding these fields in a new object allows for future expansion with less headache.

Tests augmented to check that these values are present when appropriate.

This change is co-dependent with my changes to vault-api and apollo-api; merging this will break both until those changes are merged too.
