### PR TITLE
DSDEV-1967: Add nested entity relation query depth option

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/Generic.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/model/Generic.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.vault.datamanagement.model
 
 import com.wordnik.swagger.annotations.{ApiModel, ApiModelProperty}
+
 import scala.annotation.meta.field
 
 @ApiModel("system-generated entity attributes")
@@ -25,7 +26,9 @@ case class GenericEntity(
   @(ApiModelProperty@field)("some system-generated 'when's and 'who's")
   sysAttrs: GenericSysAttrs,
   @(ApiModelProperty@field)("an open set of metadata attributes of the entity")
-  attrs: Option[Map[String,String]] )
+  attrs: Option[Map[String,String]],
+  @(ApiModelProperty@field)("an optional set of related entities")
+  relEnts: Option[Seq[GenericRelEnt]])
 
 @ApiModel("a directed relationship between two entities")
 case class GenericRelationship(
@@ -83,4 +86,6 @@ case class GenericEntityQuery(
   @(ApiModelProperty@field)("optional metadata attribute spec")
   attrSpec: Seq[GenericAttributeSpec],
   @(ApiModelProperty@field)("return metadata attributes, or skip it")
-  expandAttrs: Boolean )
+  expandAttrs: Boolean,
+  @(ApiModelProperty@field)("optional value to specify the depth of entity relationships to include")
+  depth: Option[Int] )

--- a/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/JsonImplicits.scala
+++ b/src/main/scala/org/broadinstitute/dsde/vault/datamanagement/services/JsonImplicits.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.vault.datamanagement.model.GenericEntityIngest
 import org.broadinstitute.dsde.vault.datamanagement.model.GenericRelationshipIngest
 import org.broadinstitute.dsde.vault.datamanagement.model.GenericIngest
 
-import spray.json.DefaultJsonProtocol
+import spray.json.{RootJsonFormat, DefaultJsonProtocol}
 
 object JsonImplicits extends DefaultJsonProtocol {
   // via https://github.com/jacobus/s4/blob/8dc0fbb04c788c892cb93975cf12f277006b0095/src/main/scala/s4/rest/S4Service.scala
@@ -14,12 +14,18 @@ object JsonImplicits extends DefaultJsonProtocol {
   implicit val impBAMCollection = jsonFormat4(UBamCollection)
   implicit val impEntitySearchResult = jsonFormat2(EntitySearchResult)
   implicit val impGenericSysAttrs = jsonFormat5(GenericSysAttrs)
-  implicit val impGenericEntity = jsonFormat4(GenericEntity)
+  /*
+   * See https://github.com/spray/spray-json#jsonformats-for-recursive-types
+   * for dealing with entities that reference one another. In this case, we
+   * also need to wrap it in a RootJsonFormat to avoid runtime errors in the
+   * service classes.
+   */
+  implicit val impGenericEntity: RootJsonFormat[GenericEntity] = rootFormat(lazyFormat(jsonFormat(GenericEntity, "guid", "entityType", "sysAttrs", "attrs", "relatedEntities")))
   implicit val impGenericRelationship = jsonFormat2(GenericRelationship)
   implicit val impGenericRelEnt = jsonFormat2(GenericRelEnt)
   implicit val impGenericEntityIngest = jsonFormat3(GenericEntityIngest)
   implicit val impGenericRelationshipIngest = jsonFormat4(GenericRelationshipIngest)
   implicit val impGenericIngest = jsonFormat2(GenericIngest)
   implicit val impGenericAttributeSpec = jsonFormat2(GenericAttributeSpec)
-  implicit val impGenericQuery = jsonFormat3(GenericEntityQuery)
+  implicit val impGenericQuery = jsonFormat4(GenericEntityQuery)
 }

--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/controller/DataManagementControllerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/controller/DataManagementControllerSpec.scala
@@ -54,7 +54,7 @@ class DataManagementControllerSpec extends DataManagementDatabaseFreeSpec {
           guids should have length 3
 
           // list the IDs of "unmappedBAM" entities having a "queryAttr" of someValue
-          val files = da.findEntities(GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",someValue)),false))
+          val files = da.findEntities(GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",someValue)),false,Option.empty))
           files should have length 1
           val uBAM = files(0)
           uBAM.guid shouldBe guids(0)
@@ -127,7 +127,7 @@ class DataManagementControllerSpec extends DataManagementDatabaseFreeSpec {
           guids should have length 3
 
           // list the IDs of "unmappedBAM" entities having a "queryAttr" of someValue
-          val files = da.findEntities(GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",someValue)),true))
+          val files = da.findEntities(GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",someValue)),true,Option.empty))
           files should have length 1
           val uBAM = files(0)
           uBAM.entityType shouldBe "unmappedBAM"

--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/GenericServiceNestedSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/GenericServiceNestedSpec.scala
@@ -109,9 +109,9 @@ class GenericServiceNestedSpec extends DataManagementDatabaseFreeSpec with Gener
             roots should have length 1
             val root = roots.head
             root.relEnts.get should have length 2
-            val aliquot1 = root.relEnts.get.head.entity
+            val aliquot1 = root.relEnts.get.filter(_.entity.guid == guids(1)).head.entity
             aliquot1.relEnts.get should have length 2
-            val aliquot2 = root.relEnts.get(1).entity
+            val aliquot2 = root.relEnts.get.filter(_.entity.guid == guids(2)).head.entity
             aliquot2.relEnts.get should have length 1
 
             // The depth parameter should limit further relEnts from being populated
@@ -133,10 +133,10 @@ class GenericServiceNestedSpec extends DataManagementDatabaseFreeSpec with Gener
             roots should have length 1
             val root = roots.head
             root.relEnts.get should have length 2
-            val aliquot1 = root.relEnts.get.head.entity
+            val aliquot1 = root.relEnts.get.filter(_.entity.guid == guids(1)).head.entity
             aliquot1.relEnts.get should have length 2
 
-            val aliquot3 = aliquot1.relEnts.get.head.entity
+            val aliquot3 = aliquot1.relEnts.get.filter(_.entity.guid == guids(3)).head.entity
             aliquot3.relEnts.get should have length 1
 
             // The depth parameter should limit further relEnts from being populated
@@ -152,10 +152,10 @@ class GenericServiceNestedSpec extends DataManagementDatabaseFreeSpec with Gener
             roots should have length 1
             val root = roots.head
             root.relEnts.get should have length 2
-            val aliquot1 = root.relEnts.get.head.entity
+            val aliquot1 = root.relEnts.get.filter(_.entity.guid == guids(1)).head.entity
             aliquot1.relEnts.get should have length 2
 
-            val aliquot3 = aliquot1.relEnts.get.head.entity
+            val aliquot3 = aliquot1.relEnts.get.filter(_.entity.guid == guids(3)).head.entity
             aliquot3.relEnts.get should have length 1
 
             val aliquot6 = aliquot3.relEnts.get.head.entity
@@ -171,8 +171,8 @@ class GenericServiceNestedSpec extends DataManagementDatabaseFreeSpec with Gener
           Post(findEntityPath,GenericEntityQuery("rootSample", Seq(GenericAttributeSpec("id", aValue), GenericAttributeSpec("ownerId","me")),false, Option(10))) ~>
             sealRoute(routes) ~> check {
             val roots = responseAs[List[GenericEntity]]
-            val aliquot1 = roots.head.relEnts.get.head.entity
-            val aliquot3 = aliquot1.relEnts.get.head.entity
+            val aliquot1 = roots.head.relEnts.get.filter(_.entity.guid == guids(1)).head.entity
+            val aliquot3 = aliquot1.relEnts.get.filter(_.entity.guid == guids(3)).head.entity
             val aliquot6 = aliquot3.relEnts.get.head.entity
             val aliquot7 = aliquot6.relEnts.get.head.entity
             // The depth parameter should limit further relEnts from being populated

--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/GenericServiceNestedSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/GenericServiceNestedSpec.scala
@@ -1,0 +1,187 @@
+package org.broadinstitute.dsde.vault.datamanagement.services
+
+import java.util.concurrent.TimeUnit
+
+import org.broadinstitute.dsde.vault.datamanagement.DataManagementDatabaseFreeSpec
+import org.broadinstitute.dsde.vault.datamanagement.model._
+import org.broadinstitute.dsde.vault.datamanagement.services.JsonImplicits._
+import spray.httpx.SprayJsonSupport._
+
+import scala.concurrent.duration.FiniteDuration
+
+class GenericServiceNestedSpec extends DataManagementDatabaseFreeSpec with GenericService   {
+
+  implicit val routeTestTimeout = RouteTestTimeout(new FiniteDuration(5, TimeUnit.SECONDS))
+
+  "GenericService" - {
+
+    val versions = Table(
+      "version",
+      None,
+      Option(1)
+    )
+
+    forAll(versions) { (version: Option[Int]) =>
+      val pathBase = "/entities" + v(version)
+
+      /*
+       * This models a root sample with multiple levels of child samples
+       */
+      s"when accessing the $pathBase path" - {
+        // Root sample
+        val aValue = java.util.UUID.randomUUID().toString
+        val sampleAttrs = Map("ownerId" -> "me", "id" -> aValue, "container" -> "freezer")
+
+        val aliquot1Attrs = Map("id" -> "aliquot1", "container" -> "tube")
+        val aliquot1RelAttrs = Map("name" -> "aliquot")
+
+        val aliquot2Attrs = Map("id" -> "aliquot2", "container" -> "tube")
+        val aliquot2RelAttrs = Map("name" -> "aliquot")
+
+        // Child samples for aliquot1
+        val aliquot3Attrs = Map("id" -> "aliquot3", "container" -> "plate")
+        val aliquot3RelAttrs = Map("name" -> "aliquot")
+
+        val aliquot4Attrs = Map("id" -> "aliquot4", "container" -> "plate")
+        val aliquot4RelAttrs = Map("name" -> "aliquot")
+
+        // Child sample for aliquot2
+        val aliquot5Attrs = Map("id" -> "aliquot5", "container" -> "plate")
+        val aliquot5RelAttrs = Map("name" -> "aliquot")
+
+        // Child sample for aliquot3, which is a child of aliquot1
+        val aliquot6Attrs = Map("id" -> "aliquot6", "container" -> "plate")
+        val aliquot6RelAttrs = Map("name" -> "aliquot")
+
+        // Child sample for aliquot6, which is a grandchild of aliquot1
+        val aliquot7Attrs = Map("id" -> "aliquot7", "container" -> "plate")
+        val aliquot7RelAttrs = Map("name" -> "aliquot")
+
+        val ingest = GenericIngest(
+            Some(List(GenericEntityIngest("rootSample",None,sampleAttrs),
+                      GenericEntityIngest("sample",None,aliquot1Attrs),
+                      GenericEntityIngest("sample",None,aliquot2Attrs),
+                      GenericEntityIngest("sample",None,aliquot3Attrs),
+                      GenericEntityIngest("sample",None,aliquot4Attrs),
+                      GenericEntityIngest("sample",None,aliquot5Attrs),
+                      GenericEntityIngest("sample",None,aliquot6Attrs),
+                      GenericEntityIngest("sample",None,aliquot7Attrs)
+            )),
+            Some(List(GenericRelationshipIngest("aliquot","$0","$1",aliquot1RelAttrs),
+                      GenericRelationshipIngest("aliquot","$0","$2",aliquot2RelAttrs),
+                      GenericRelationshipIngest("aliquot","$1","$3",aliquot3RelAttrs),
+                      GenericRelationshipIngest("aliquot","$1","$4",aliquot4RelAttrs),
+                      GenericRelationshipIngest("aliquot","$2","$5",aliquot5RelAttrs),
+                      GenericRelationshipIngest("aliquot","$3","$6",aliquot6RelAttrs),
+                      GenericRelationshipIngest("aliquot","$6","$7",aliquot7RelAttrs)
+            )))
+
+        var guids: List[String] = List.empty[String]
+
+        "POST should store a new sample generically" in {
+          Post(s"$pathBase", ingest) ~> openAMSession ~> sealRoute(routes) ~> check {
+            guids = responseAs[List[String]]
+            guids should have length 8
+          }
+        }
+
+        val findEntityPath = s"$pathBase/search"
+        "findEntities should retrieve the children of a root sample" in {
+          Post(findEntityPath,GenericEntityQuery("rootSample", Seq(GenericAttributeSpec("id", aValue), GenericAttributeSpec("ownerId","me")),false, Option(1))) ~>
+            sealRoute(routes) ~> check {
+            val roots = responseAs[List[GenericEntity]]
+            roots should have length 1
+            val root = roots.head
+            root.relEnts.get should have length 2
+
+            // The depth parameter should have limited further relEnts from being populated
+            root.relEnts.get.foreach {
+              relEnt: GenericRelEnt =>
+                relEnt.entity.relEnts should be (Option.empty)
+            }
+          }
+        }
+
+        "findEntities should retrieve the grand-children of a root sample" in {
+          Post(findEntityPath,GenericEntityQuery("rootSample", Seq(GenericAttributeSpec("id", aValue), GenericAttributeSpec("ownerId","me")),false, Option(2))) ~>
+            sealRoute(routes) ~> check {
+            val roots = responseAs[List[GenericEntity]]
+            roots should have length 1
+            val root = roots.head
+            root.relEnts.get should have length 2
+            val aliquot1 = root.relEnts.get.head.entity
+            aliquot1.relEnts.get should have length 2
+            val aliquot2 = root.relEnts.get(1).entity
+            aliquot2.relEnts.get should have length 1
+
+            // The depth parameter should limit further relEnts from being populated
+            aliquot1.relEnts.get.foreach {
+              relEnt: GenericRelEnt =>
+                relEnt.entity.relEnts should be (Option.empty)
+            }
+            aliquot2.relEnts.get.foreach {
+              relEnt: GenericRelEnt =>
+                relEnt.entity.relEnts should be (Option.empty)
+            }
+          }
+        }
+
+        "findEntities should retrieve the great grand-children of a root sample" in {
+          Post(findEntityPath,GenericEntityQuery("rootSample", Seq(GenericAttributeSpec("id", aValue), GenericAttributeSpec("ownerId","me")),false, Option(3))) ~>
+            sealRoute(routes) ~> check {
+            val roots = responseAs[List[GenericEntity]]
+            roots should have length 1
+            val root = roots.head
+            root.relEnts.get should have length 2
+            val aliquot1 = root.relEnts.get.head.entity
+            aliquot1.relEnts.get should have length 2
+
+            val aliquot3 = aliquot1.relEnts.get.head.entity
+            aliquot3.relEnts.get should have length 1
+
+            // The depth parameter should limit further relEnts from being populated
+            val aliquot6 = aliquot3.relEnts.get.head.entity
+            aliquot6.relEnts should be (Option.empty)
+          }
+        }
+
+        "findEntities should retrieve the great great grand-children of a root sample" in {
+          Post(findEntityPath,GenericEntityQuery("rootSample", Seq(GenericAttributeSpec("id", aValue), GenericAttributeSpec("ownerId","me")),false, Option(4))) ~>
+            sealRoute(routes) ~> check {
+            val roots = responseAs[List[GenericEntity]]
+            roots should have length 1
+            val root = roots.head
+            root.relEnts.get should have length 2
+            val aliquot1 = root.relEnts.get.head.entity
+            aliquot1.relEnts.get should have length 2
+
+            val aliquot3 = aliquot1.relEnts.get.head.entity
+            aliquot3.relEnts.get should have length 1
+
+            val aliquot6 = aliquot3.relEnts.get.head.entity
+            aliquot6.relEnts.get should have length 1
+
+            // The depth parameter should limit further relEnts from being populated
+            val aliquot7 = aliquot6.relEnts.get.head.entity
+            aliquot7.relEnts should be (Option.empty)
+          }
+        }
+
+        "findEntities should limit the depth retrieved" in {
+          Post(findEntityPath,GenericEntityQuery("rootSample", Seq(GenericAttributeSpec("id", aValue), GenericAttributeSpec("ownerId","me")),false, Option(10))) ~>
+            sealRoute(routes) ~> check {
+            val roots = responseAs[List[GenericEntity]]
+            val aliquot1 = roots.head.relEnts.get.head.entity
+            val aliquot3 = aliquot1.relEnts.get.head.entity
+            val aliquot6 = aliquot3.relEnts.get.head.entity
+            val aliquot7 = aliquot6.relEnts.get.head.entity
+            // The depth parameter should limit further relEnts from being populated
+            aliquot7.relEnts should be (Option.empty)
+          }
+        }
+
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/GenericServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/vault/datamanagement/services/GenericServiceSpec.scala
@@ -46,7 +46,7 @@ class GenericServiceSpec extends DataManagementDatabaseFreeSpec with GenericServ
 
         val findEntityPath = s"$pathBase/search"
         "findEntities should retrieve the ID of the bam file" in {
-          Post(findEntityPath,GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",aValue),GenericAttributeSpec("ownerId","me")),false)) ~>
+          Post(findEntityPath,GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",aValue),GenericAttributeSpec("ownerId","me")),false,Option.empty)) ~>
             sealRoute(routes) ~> check {
             val files = responseAs[List[GenericEntity]]
             files should have length 1
@@ -56,7 +56,7 @@ class GenericServiceSpec extends DataManagementDatabaseFreeSpec with GenericServ
         }
 
         "findEntities should retrieve the ID and attributes of the bam file" in {
-          Post(findEntityPath,GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",aValue),GenericAttributeSpec("ownerId","me")),true)) ~>
+          Post(findEntityPath,GenericEntityQuery("unmappedBAM",Seq(GenericAttributeSpec("queryAttr",aValue),GenericAttributeSpec("ownerId","me")),true,Option.empty)) ~>
                       sealRoute(routes) ~> check {
             val files = responseAs[List[GenericEntity]]
             files should have length 1
@@ -68,7 +68,7 @@ class GenericServiceSpec extends DataManagementDatabaseFreeSpec with GenericServ
         }
 
         "findEntities with bogus attribute value should return NOT FOUND" in {
-          Post(findEntityPath,GenericEntityQuery("file",Seq(GenericAttributeSpec("path","foo")),false)) ~> sealRoute(routes) ~> check {
+          Post(findEntityPath,GenericEntityQuery("file",Seq(GenericAttributeSpec("path","foo")),false,Option.empty)) ~> sealRoute(routes) ~> check {
             val files = responseAs[List[GenericEntity]]
             files should have length 0
           }


### PR DESCRIPTION
This PR adds an optional depth parameter to `GenericEntityQuery` which will follow entity relations out to the specified depth. I added a completely separate test to handle this that models root samples and aliquots - see `GenericServiceNestedSpec` for an example of how to construct the relationships. Feedback especially requested for `DataAccess.findDownstreamToDepth`
